### PR TITLE
Fix some wristwatch issues

### DIFF
--- a/hud/hudteammatevr.lua
+++ b/hud/hudteammatevr.lua
@@ -40,7 +40,15 @@ function HUDTeammateVR:_create_radial_health(radial_health_panel)
 
 	radial_health_panel = get_health_panel(self)
 	self._radial_health_panel = radial_health_panel
-
+	local health_icon = radial_health_panel:bitmap({
+		blend_mode = "add",
+		name = "health_icon",
+		alpha = 0,
+		texture = "guis/textures/pd2/progress_health_icon",
+		layer = 1,
+		w = radial_health_panel:w(),
+		h = radial_health_panel:h()
+	})
 	local radial_bg = radial_health_panel:bitmap({
 		texture = "guis/textures/pd2/progress_warp_black",
 		name = "radial_bg",
@@ -128,6 +136,7 @@ function HUDTeammateVR:_create_radial_health(radial_health_panel)
 		blend_mode = "add",
 		name = "ability_icon",
 		alpha = 1,
+		texture = "guis/textures/pd2/add_icon",
 		layer = 5,
 		w = radial_size * 0.5,
 		h = radial_size * 0.5


### PR DESCRIPTION
-Fix crash when going into custody after using an ability.
-Fix ability icon turning into just a white square.

These issues only apply when using the 'Wristwatch Health Display' option in the UI Options.

This should fix the following crash:
> Application has crashed: C++ exception
[string "lib/managers/hud/vr/hudteammatevr.lua"]:843: attempt to index local 'health_icon' (a nil value)
>
>SCRIPT STACK
>
>set_teammate_ability_radial() lib/managers/hudmanagerpd2.lua:369
set_player_ability_radial() lib/managers/hudmanagerpd2.lua:365
reset_ability_hud() lib/managers/playermanager.lua:6273
on_enter_custody() lib/managers/playermanager.lua:5859
update() lib/states/ingamebleedout.lua:20
update() core/lib/utils/game_state_machine/coregamestatemachine.lua:92
update() lib/setups/setup.lua:940
original() lib/setups/gamesetup.lua:802
update() [@mods](https://modworkshop.net/user/mods)/base/req/core/Hooks.lua:264
update() lib/setups/networkgamesetup.lua:21
core/lib/setups/coresetup.lua:559